### PR TITLE
index.js: ensure memberOf is an array.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,9 @@ Auth.prototype.authenticate = function(user, password, callback) {
     if (ldap_user) {
       var groups = [ user ]
       if ('memberOf' in ldap_user) {
+        if (!Array.isArray(ldap_user.memberOf)) {
+          ldap_user.memberOf = [ ldap_user.memberOf ]
+        }
         for (var i = 0; i < ldap_user.memberOf.length; i++) {
           groups.push("%" + parseDN(ldap_user.memberOf[i]).rdns[0][self._config.groupNameAttribute])
         }


### PR DESCRIPTION
When ldap_user is only a member of 1 group, the memberOf attribute
is a string containing a dn (not an array if dn strings). The for-loop
is designed to work with an array of dn strings, so when a user
who is a member of just one group is encountered, the module crashes
because the for-loop is iterating over each character in the string.
This patch adds a check to see if memberOf is an Array. If it isn't
an array, it makes it an array.
