### PR TITLE
Create a new LDAP client for each request and also close the connection.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,6 @@ function Auth(config, stuff) {
 
   // TODO: Set more defaults
   self._config.groupNameAttribute = self._config.groupNameAttribute || 'cn'
-  self._ldap = new LdapAuth(self._config.client_options)
 
   return self
 }
@@ -27,8 +26,9 @@ function Auth(config, stuff) {
 //
 Auth.prototype.authenticate = function(user, password, callback) {
   var self = this
+  var LdapClient = new LdapAuth(self._config.client_options)
 
-  self._ldap.authenticate(user, password, function(err, ldap_user) {
+  LdapClient.authenticate(user, password, function(err, ldap_user) {
     if (err) {
       // 'No such user' is reported via error
       self._logger.warn({
@@ -51,5 +51,13 @@ Auth.prototype.authenticate = function(user, password, callback) {
     }
 
     callback(null, groups)
+  })
+
+  LdapClient.close(function(err) {
+    if (err) {
+      self._logger.warn({
+         err: err
+        }, 'LDAP error on close @{err}')
+     }
   })
 }


### PR DESCRIPTION
After running for 20 minutes or so the plugin stopped working leaving us with this error:

err":{"message":"write after end","name":"Error","stack":"Error: write after end\n    at writeAfterEnd (_stream_writable.js:167:12)\n    at Socket.Writable.write (_stream_writable.js:214:5)\n    at Socket.write (net.js:625:40)\n    at Client._send (/usr/lib/node_modules/sinopia-ldap/node_modules/ldapjs/lib/client/client.js:914:17)\n    at Client.search (/usr/lib/node_modules/sinopia-ldap/node_modules/ldapjs/lib/client/client.js:678:15)\n    at /usr/lib/node_modules/sinopia-ldap/node_modules/ldapauth-fork/lib/ldapauth.js:197:23\n    at LdapAuth._adminBind (/usr/lib/node_modules/sinopia-ldap/node_modules/ldapauth-fork/lib/ldapauth.js:165:12)\n    at LdapAuth._search (/usr/lib/node_modules/sinopia-ldap/node_modules/ldapauth-fork/lib/ldapauth.js:193:8)\n    at LdapAuth._findUser (/usr/lib/node_modules/sinopia-ldap/node_modules/ldapauth-fork/lib/ldapauth.js:242:8)\n    at LdapAuth.authenticate (/usr/lib/node_modules/sinopia-ldap/node_modules/ldapauth-fork/lib/ldapauth.js:298:8)"},"msg":"LDAP error @{err}","time":"2015-04-29T09:01:05.022Z","v":0}

This problem goes away if you create a new ldap client instance for each query.
I've created a patch that solves this issue for us, pull if you like :)